### PR TITLE
Better `distance` & add `nearest_stop`

### DIFF
--- a/robusta/src/kvv.rs
+++ b/robusta/src/kvv.rs
@@ -342,3 +342,16 @@ pub fn train_positions(departures_per_line: &LineDepartures, render_time: DateTi
         .flat_map(|(journey_ref, departures)| train_position_per_route(render_time, journey_ref, departures, stops))
         .collect()
 }
+
+pub fn nearest_stop(pos: Point) -> &'static Stop {
+    let stops = KVV_STOPS.get().expect("KVV_STOPS not initialized");
+    stops
+        .iter()
+        .min_by_key(|stop| {
+            pos.distance(Point {
+                latitude: stop.lat as f32,
+                longitude: stop.lon as f32,
+            }) as u64
+        })
+        .expect("no stops")
+}

--- a/robusta/src/point.rs
+++ b/robusta/src/point.rs
@@ -5,8 +5,15 @@ pub struct Point {
 }
 
 impl Point {
+    /// The approximate distance between two points in meters, using equirectangular projection.
     pub fn distance(self, other: Self) -> f32 {
-        f32::hypot(other.latitude - self.latitude, other.longitude - self.longitude)
+        // the radius of the earth in meters
+        const EARTH_RADIUS: f32 = 6371008.8;
+
+        let delta_lat = (other.latitude - self.latitude).to_radians();
+        let delta_lon = (other.longitude - self.longitude).to_radians();
+        let mean_lat = (self.latitude + other.latitude) / 2.0;
+        EARTH_RADIUS * f32::hypot(delta_lat, f32::cos(mean_lat) * delta_lon)
     }
 
     /// Linear interpolation.


### PR DESCRIPTION
The current `distance` function is quite wrong. This one is reasonably accurate for small distances and still relatively cheap. `nearest_stop` will be needed for determining the Mr. X position.